### PR TITLE
Add true test file path and line number replacement

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -62,7 +62,14 @@ const runTest = file => new Promise((resolve, reject) => {
     if (!code) {
       resolve(output);
     } else {
-      reject(output);
+      const mochaFile = fs.readFileSync(path.join(__dirname, 'src', 'mocha.mjs'), 'utf8');
+      const mochaFileLinesCount = mochaFile.split('\n').length;
+
+      const formatedOutput = output.replace(new RegExp(`(${testFilePath}:)(.+):`), (match, fileName, lineNumber) => {
+        return `${file}:${+lineNumber - mochaFileLinesCount + 1}:`
+      });
+
+      reject(formatedOutput);
     }
   });
 });


### PR DESCRIPTION
I made it so that in the error-stack of the error thrown from the test file is displayed with the real path to the test file, not the temporary version with a random name. And now the line number with an error is correctly calculated, taking into account the concatenated mocha.mjs at the beginning of the file.

Before:
![image](https://user-images.githubusercontent.com/33148533/46797135-fec4ec00-cd56-11e8-9f32-5a598057fbee.png)


After:
![image](https://user-images.githubusercontent.com/33148533/46797104-ebb21c00-cd56-11e8-9d9d-948c1bc5eac4.png)
